### PR TITLE
Fix tests to run with `zope.component >= 5`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ CHANGES
 
 - Drop support for Python 3.4.
 
+- Fix tests to run with ``zope.component >= 5``.
+
 
 4.0.1 (2017-05-15)
 ------------------

--- a/src/zope/app/exception/browser/tests/test_error.py
+++ b/src/zope/app/exception/browser/tests/test_error.py
@@ -15,10 +15,10 @@
 """
 import doctest
 import unittest
-from zope.component.interfaces import ComponentLookupError
-from zope.app.exception.testing import AppExceptionLayer
 from zope.app.exception.browser.tests import BrowserTestCase
+from zope.app.exception.testing import AppExceptionLayer
 from zope.app.wsgi.testlayer import http
+from zope.interface.interfaces import ComponentLookupError
 
 
 class RaiseError(object):

--- a/src/zope/app/exception/browser/tests/test_unauthorized.py
+++ b/src/zope/app/exception/browser/tests/test_unauthorized.py
@@ -94,7 +94,7 @@ class Test(PlacelessSetup, unittest.TestCase):
                          'no-store, no-cache, must-revalidate')
 
         # Make sure the auth utility was called
-        self.failUnless(self.auth.request is request)
+        self.assertIs(self.auth.request, request)
         self.assertEqual(self.auth.principal_id, 23)
 
     def testRedirect(self):
@@ -112,19 +112,15 @@ class Test(PlacelessSetup, unittest.TestCase):
         res = u()
 
         # Make sure that the template was not rendered
-        self.assert_(res is None)
+        self.assertIsNone(res)
 
         # Make sure the auth's redirect is honored
         self.assertEqual(request.response.getStatus(), 303)
 
         # Make sure the auth utility was called
-        self.failUnless(self.auth.request is request)
+        self.assertIs(self.auth.request, request)
         self.assertEqual(self.auth.principal_id, 23)
 
 
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='test_suite')


### PR DESCRIPTION
Plus fix some deprecation warnings.